### PR TITLE
fix(ci): Resume Continuous Integration testing for gcp-bucket-manifest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ google.api_core==1.20.0
 google-cloud-storage==1.30.0
 apache-beam[gcp]==2.21.0
 setuptools>=40.3.0
-google-cloud-pubsub==1.5.0


### PR DESCRIPTION
This PR solves this problem:
```
ERROR: Cannot install apache-beam[gcp]==2.21.0 and google-cloud-pubsub==1.5.0 because these package versions have conflicting dependencies.
```